### PR TITLE
chore: enable experimental free gil test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,9 +39,14 @@ jobs:
     strategy:
       matrix:
         python-version: [
-          "3.10", "3.11", "3.12", "3.13", "3.14"
+          "3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"
         ]
         os: [ubuntu-latest, macos-latest, windows-latest]
+        include:
+          - python-version: "3.14t"
+            experimental: true
+
+    continue-on-error: ${{ matrix.experimental == true }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,6 +60,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Test Python
+        env:
+          PYTHON_GIL: ${{ matrix.experimental == true && '0' || '1' }}
         run: just test-python
 
       - name: Test Rust

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -12,3 +12,4 @@ Authors
 * Nicholas Bunn - https://github.com/NicholasBunn
 * Nathan McDougall - https://github.com/nathanjmcdougall
 * Oleksandr Zaiats - https://github.com/z4y4ts
+* Pablo Aguilar - https://github.com/thepabloaguilar


### PR DESCRIPTION
This PRs adds Python version "3.14 __t__" to the test matrix, that version is the free GIL version, I've added it as experimental so if something does not work now or in the future from incoming changes it won't break the pipeline.

This is a good start to try making this compliant with free GIL version because:
- We can see where we need to work on
- Where breaking compatibility changes were added

But of course it doesn't mean if nothing is raised during test this lib is already compliant, it's just a first step towards compatibility.

- [ ] Add tests for the change. In general, aim for full test coverage at the Python level. Rust tests are optional.
- [ ] Add any appropriate documentation.
- [ ] Add a summary of changes to the `latest` section at the top of `CHANGELOG.rst`. (If it's not there, add it.)
- [x] Add your name to `AUTHORS.rst`.
- [ ] Run `just full-check`.

Ref #297 