### PR TITLE
Support freethreaded Python 3.14

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       matrix:
         python-version: [
-          "3.10", "3.11", "3.12", "3.13", "3.14"
+          "3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"
         ]
         os: [ubuntu-latest, macos-latest, windows-latest]
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,7 @@ jobs:
             3.12
             3.13
             3.14
+            3.14t
           allow-prereleases: true
       - name: Build wheels
         uses: PyO3/maturin-action@v1
@@ -79,6 +80,7 @@ jobs:
             3.12
             3.13
             3.14
+            3.14t
           allow-prereleases: true
       - name: Build wheels
         uses: PyO3/maturin-action@v1
@@ -112,6 +114,7 @@ jobs:
             3.12
             3.13
             3.14
+            3.14t
           allow-prereleases: true
           architecture: ${{ matrix.platform.target }}
       - name: Build wheels
@@ -145,6 +148,7 @@ jobs:
             3.12
             3.13
             3.14
+            3.14t
           allow-prereleases: true
       - name: Build wheels
         uses: PyO3/maturin-action@v1

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ latest
 
 * Fix panic error when scanning imports of nonexistent namespace children
   (https://github.com/python-grimp/grimp/issues/308).
+* Officially support freethreaded Python 3.14.
 
 3.15 (2026-07-03)
 -----------------

--- a/justfile
+++ b/justfile
@@ -38,6 +38,7 @@ test-all:
     just test-python 3.12
     just test-python 3.13
     just test-python 3.14
+    just test-python 3.14t
     just test-rust
 
 # Populate missing Syrupy snapshots.


### PR DESCRIPTION
Added testing for freethreaded Python 3.14, together with wheel-building on release.

3.13t is not supported by PyO3, so we don't support it either.

