### PR TITLE
Add Windows ARM64 build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,12 +108,15 @@ jobs:
             target: x64
           - runner: windows-latest
             target: x86
+          - runner: windows-11-arm
+            target: aarch64
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v6
         with:
+          # CPython has no official Windows ARM64 build before 3.11.
           python-version: |
-            3.10
+            ${{ matrix.platform.target != 'aarch64' && '3.10' || '' }}
             3.11
             3.12
             3.13
@@ -122,7 +125,7 @@ jobs:
             3.15
             3.15t
           allow-prereleases: true
-          architecture: ${{ matrix.platform.target }}
+          architecture: ${{ matrix.platform.target == 'aarch64' && 'arm64' || matrix.platform.target }}
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,32 +106,45 @@ jobs:
         platform:
           - runner: windows-latest
             target: x64
+            interpreters: &interpreters '["3.10", "3.11", "3.12", "3.13", "3.14", "3.15"]'
+            free-threaded-interpreters: &free-threaded-interpreters '["3.14t", "3.15t"]'
           - runner: windows-latest
             target: x86
+            interpreters: *interpreters
+            free-threaded-interpreters: *free-threaded-interpreters
+          # setup-python has no Windows ARM64 builds before 3.11.
           - runner: windows-11-arm
             target: aarch64
+            interpreters: '["3.11", "3.12", "3.13", "3.14", "3.15"]'
+            free-threaded-interpreters: *free-threaded-interpreters
     steps:
       - uses: actions/checkout@v5
+
+      # https://github.com/pyo3/maturin-action#windows-build-the-regular-and-free-threaded-interpreters-in-separate-jobs
       - uses: actions/setup-python@v6
         with:
-          # CPython has no official Windows ARM64 build before 3.11.
-          python-version: |
-            ${{ matrix.platform.target != 'aarch64' && '3.10' || '' }}
-            3.11
-            3.12
-            3.13
-            3.14
-            3.14t
-            3.15
-            3.15t
+          python-version: ${{ join(fromJSON(matrix.platform.interpreters), fromJSON('"\n"')) }}
           allow-prereleases: true
           architecture: ${{ matrix.platform.target == 'aarch64' && 'arm64' || matrix.platform.target }}
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist --find-interpreter
+          args: --release --out dist --interpreter ${{ join(fromJSON(matrix.platform.interpreters), ' ') }}
           sccache: 'true'
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ join(fromJSON(matrix.platform.free-threaded-interpreters), fromJSON('"\n"')) }}
+          allow-prereleases: true
+          architecture: ${{ matrix.platform.target == 'aarch64' && 'arm64' || matrix.platform.target }}
+      - name: Build free-threaded wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.platform.target }}
+          args: --release --out dist --interpreter ${{ join(fromJSON(matrix.platform.free-threaded-interpreters), ' ') }}
+          sccache: 'true'
+
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -12,3 +12,4 @@ Authors
 * Nicholas Bunn - https://github.com/NicholasBunn
 * Nathan McDougall - https://github.com/nathanjmcdougall
 * Oleksandr Zaiats - https://github.com/z4y4ts
+* Nikhil Dabas - https://github.com/ndabas

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ latest
   (https://github.com/python-grimp/grimp/issues/308).
 * Officially support freethreaded Python 3.14+.
 * Officially support Python 3.15, including lazy imports.
+* Officially support Windows ARM64 Python 3.11+, including freethreaded 3.14+.
 
 3.15 (2026-07-03)
 -----------------


### PR DESCRIPTION
- [ ] Add tests for the change. In general, aim for full test coverage at the Python level. Rust tests are optional.
- [x] Add any appropriate documentation.
- [x] Add a summary of changes to the `latest` section at the top of `CHANGELOG.rst`. (If it's not there, add it.)
- [x] Add your name to `AUTHORS.rst`.
- [ ] Run `just full-check`.

As the title says.

The changes look slightly crazy because:
- setup-python (and official CPython) only have binary releases from 3.11 onward.
- maturin expects `aarch64` as the architecture while setup-python wants to see `arm64`.
- There was an existing issue in the release workflow which caused only free-threaded wheels to be built for Windows x86 and x64. [This is a known issue](https://github.com/pyo3/maturin-action#windows-build-the-regular-and-free-threaded-interpreters-in-separate-jobs). So I have added a separate step to build the free-threaded wheels as per the recommended workaround.